### PR TITLE
Sets state on power-up

### DIFF
--- a/garage-door.yml
+++ b/garage-door.yml
@@ -49,6 +49,7 @@ binary_sensor:
     filters:
       - delayed_on: 10ms
     disabled_by_default: false
+    publish_initial_state: true
     on_state:
       then:
         - if:
@@ -78,6 +79,7 @@ binary_sensor:
     filters:
       - delayed_on: 10ms
     disabled_by_default: false
+    publish_initial_state: true
     on_state:
       then:
         - if:


### PR DESCRIPTION
This update sets the initial state of the system.
I noticed this when testing. I powered up the Pico with the switch off and the Pico LED (door open) did not come on.
Note that this is my first project on the Pico and the first on ESPHome, so there may be a better way to do this.
FYI, I am having a great time figuring out how all of this stuff works.