### PR TITLE
🎨 set the HA device class to garage door

### DIFF
--- a/garage-door.yml
+++ b/garage-door.yml
@@ -45,7 +45,7 @@ binary_sensor:
       inverted: false
     name: East Garage Door
     id: east_garage_door
-    device_class: door
+    device_class: garage_door
     filters:
       - delayed_on: 10ms
     disabled_by_default: false
@@ -75,7 +75,7 @@ binary_sensor:
       inverted: false
     name: West Garage Door
     id: west_garage_door
-    device_class: door
+    device_class: garage_door
     filters:
       - delayed_on: 10ms
     disabled_by_default: false


### PR DESCRIPTION
Changed the device classes of the sensors from regular doors to garage doors for Home Assistant.