### PR TITLE
api password deprecated, use api encryption key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ota_password: choose-an-ota-password
 api_encryption_key: choose-an-api-encryption-key
 ```
 
-**Note**: The [ESPHome docs API page](https://esphome.io/components/api.html) can generate an encryption key in-browser.
+> **Note**: The [ESPHome docs API page](https://esphome.io/components/api.html) can generate an encryption key in-browser.
 
 ### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Create a `secrets.yaml` file inside this directory, and add the following:
 wifi_ssid: your-wifi-ssid-here
 wifi_password: your-wifi-password-here
 ota_password: choose-an-ota-password
-api_password: choose-an-api-password
+api_encryption_key: choose-an-api-encryption-key
 ```
+
+**Note**: The [ESPHome docs API page](https://esphome.io/components/api.html) can generate an encryption key in-browser.
 
 ### Using Docker
 

--- a/garage-door.yml
+++ b/garage-door.yml
@@ -18,7 +18,8 @@ ota:
   password: !secret ota_password
 
 api:
-  password: !secret api_password
+  encryption:
+    key: !secret api_encryption_key
 
 logger:
   level: DEBUG


### PR DESCRIPTION
According to the ESPHome docs https://esphome.io/components/api.html use of api password is deprecated, and it now gives a warning when used.